### PR TITLE
Add setBlocking function

### DIFF
--- a/System/HIDAPI.hsc
+++ b/System/HIDAPI.hsc
@@ -247,8 +247,8 @@ foreign import ccall unsafe "hidapi/hidapi.h hid_send_feature_report"
 foreign import ccall unsafe "hidapi/hidapi.h hid_set_nonblocking"
   hid_set_nonblocking :: Device -> CInt -> IO CInt
 
-setBlocking :: Device -- |^ USB Device to act on, see open, openPath or openDeviceInfo
-            -> Bool   -- |^ True -> read blocks; False -> read may return immediately with 0 bytes read
+setBlocking :: Device -- USB Device to act on, see open, openPath or openDeviceInfo
+            -> Bool   -- True -> read blocks; False -> read may return immediately with 0 bytes read
             -> IO ()
 setBlocking dev blocking = do
   n' <- hid_set_nonblocking dev $ if blocking then 0 else 1

--- a/System/HIDAPI.hsc
+++ b/System/HIDAPI.hsc
@@ -8,6 +8,7 @@ module System.HIDAPI
   , open, openPath, openDeviceInfo
   , close
   , System.HIDAPI.read
+  , System.HIDAPI.setBlocking
   , System.HIDAPI.write
   , System.HIDAPI.getFeatureReport
   , System.HIDAPI.sendFeatureReport
@@ -242,6 +243,16 @@ foreign import ccall unsafe "hidapi/hidapi.h hid_get_feature_report"
 
 foreign import ccall unsafe "hidapi/hidapi.h hid_send_feature_report"
   hid_send_feature_report :: Device -> Ptr CChar -> CSize -> IO CInt
+
+foreign import ccall unsafe "hidapi/hidapi.h hid_set_nonblocking"
+  hid_set_nonblocking :: Device -> CInt -> IO CInt
+
+setBlocking :: Device -- |^ USB Device to act on, see `open', `openPath' or `openDeviceInfo'
+            -> Bool   -- |^ True -> `read' blocks; False -> `read' may return immediately with 0 bytes read
+            -> IO ()
+setBlocking dev blocking = do
+  n' <- hid_set_nonblocking dev $ if blocking then 0 else 1
+  checkWithHidError (n' /= -1) dev "Unable to set blocking mode" "hid_set_nonblocking returned -1"
 
 read :: Device -> Int -> IO ByteString
 read dev n = allocaBytes n $ \b -> do

--- a/System/HIDAPI.hsc
+++ b/System/HIDAPI.hsc
@@ -247,8 +247,8 @@ foreign import ccall unsafe "hidapi/hidapi.h hid_send_feature_report"
 foreign import ccall unsafe "hidapi/hidapi.h hid_set_nonblocking"
   hid_set_nonblocking :: Device -> CInt -> IO CInt
 
-setBlocking :: Device -- |^ USB Device to act on, see `open', `openPath' or `openDeviceInfo'
-            -> Bool   -- |^ True -> `read' blocks; False -> `read' may return immediately with 0 bytes read
+setBlocking :: Device -- |^ USB Device to act on, see open, openPath or openDeviceInfo
+            -> Bool   -- |^ True -> read blocks; False -> read may return immediately with 0 bytes read
             -> IO ()
 setBlocking dev blocking = do
   n' <- hid_set_nonblocking dev $ if blocking then 0 else 1


### PR DESCRIPTION
I needed non-blocking reads, so I added 2 wrappers for hidapi's `hid_set_nonblocking` function: `set_blocking` and `set_nonblocking`.

PS: I also tried to wrap `hid_read_timeout` in the same way but it didn't work for me (always returns -1), so I will implement a polling mechanism in my application using `set_nonblocking`.  I didn't include that polling function in Test.hs because I feel `hid_read_timeout` would be the right way to go instead of polling.  But if you want that function as example code, just ask.